### PR TITLE
歩きタバコ報告の送信失敗とLoad failed表示を修正

### DIFF
--- a/backend/src/handlers/reports.ts
+++ b/backend/src/handlers/reports.ts
@@ -71,9 +71,13 @@ export async function handleReportSubmission(request: Request, env: Env): Promis
     const location = await getLocationName(lat, lon);
 
     // Insert report using HTTP API
+    // RLS only permits the service role to insert reports. Keep the anon key as
+    // a development fallback so the API returns Supabase's explicit error when
+    // a local environment has not configured the service role yet.
+    const writeKey = env.SUPABASE_SERVICE_ROLE_KEY || env.SUPABASE_ANON_KEY;
     const supabaseResponse = await fetch(`${env.SUPABASE_URL}/rest/v1/reports`, {
       method: 'POST',
-      headers: createSupabaseHeaders(env.SUPABASE_ANON_KEY, {
+      headers: createSupabaseHeaders(writeKey, {
         'Content-Type': 'application/json',
         'Prefer': 'return=minimal'
       }),

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,16 +3,29 @@ import { handleHeatmapRequest, handleHeatmapStats } from './handlers/heatmap';
 import { handleExportCSV, handleExportExcel } from './handlers/export';
 import { Env } from './types';
 
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+function withCors(response: Response): Response {
+  const headers = new Headers(response.headers);
+
+  Object.entries(corsHeaders).forEach(([name, value]) => {
+    headers.set(name, value);
+  });
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
-    
-    // CORS headers
-    const corsHeaders = {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-    };
 
     // Handle CORS preflight
     if (request.method === 'OPTIONS') {
@@ -50,27 +63,27 @@ export default {
     }
 
     if (url.pathname === '/api/reports' && request.method === 'POST') {
-      return handleReportSubmission(request, env);
+      return withCors(await handleReportSubmission(request, env));
     }
 
     if (url.pathname === '/api/heatmap' && request.method === 'GET') {
-      return handleHeatmapRequest(request, env);
+      return withCors(await handleHeatmapRequest(request, env));
     }
 
     if (url.pathname === '/api/heatmap/stats' && request.method === 'GET') {
-      return handleHeatmapStats(request, env);
+      return withCors(await handleHeatmapStats(request, env));
     }
 
     if (url.pathname === '/api/export/csv' && request.method === 'GET') {
-      return handleExportCSV(request, env);
+      return withCors(await handleExportCSV(request, env));
     }
 
     if (url.pathname === '/api/admin/export/csv' && request.method === 'GET') {
-      return handleExportCSV(request, env);
+      return withCors(await handleExportCSV(request, env));
     }
 
     if (url.pathname === '/api/admin/export/excel' && request.method === 'GET') {
-      return handleExportExcel(request, env);
+      return withCors(await handleExportExcel(request, env));
     }
 
     // 404 for other routes

--- a/frontend/src/components/ReportForm.tsx
+++ b/frontend/src/components/ReportForm.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { GEOLOCATION_AUTO_FETCH_CHANGED_EVENT, useGeolocation } from '@/hooks/useGeolocation';
 import { useRateLimit } from '@/hooks/useRateLimit';
-import { apiClient } from '@/lib/supabase';
+import { apiClient } from '@/lib/apiClient';
 import { ReportCategory } from '@/types';
 import { MiniHeatmap } from '@/components/MiniHeatmap';
 import { trackReportSubmission } from '@/components/GoogleAnalytics';

--- a/frontend/src/hooks/useHeatmap.ts
+++ b/frontend/src/hooks/useHeatmap.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { apiClient } from '@/lib/supabase';
+import { apiClient } from '@/lib/apiClient';
 import { HeatmapData } from '@/types';
 
 const DEFAULT_NEARBY_RADIUS_METERS = 400;

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,0 +1,96 @@
+type ApiErrorBody = {
+  error?: unknown;
+};
+
+async function readApiError(response: Response): Promise<string | null> {
+  try {
+    const body = await response.json() as ApiErrorBody;
+    return typeof body.error === 'string' ? body.error : null;
+  } catch {
+    return null;
+  }
+}
+
+// API client for backend communication
+export const apiClient = {
+  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8787',
+
+  async submitReport(data: {
+    lat: number;
+    lon: number;
+    category: 'walk_smoke' | 'stand_smoke';
+  }) {
+    let response: Response;
+
+    try {
+      response = await fetch(`${this.baseUrl}/api/reports`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+    } catch (error) {
+      console.error('Report submission connection failed:', error);
+      throw new Error('報告サーバーに接続できません。時間をおいてからもう一度お試しください。');
+    }
+
+    if (!response.ok) {
+      const apiError = await readApiError(response);
+      console.error('Report submission failed:', {
+        status: response.status,
+        error: apiError,
+      });
+
+      if (response.status === 429) {
+        throw new Error('短時間に投稿が集中しています。少し時間をおいてから再度お試しください。');
+      }
+
+      if (response.status >= 500) {
+        throw new Error('現在、報告を保存できません。時間をおいてからもう一度お試しください。');
+      }
+
+      throw new Error(apiError || '報告の送信に失敗しました。入力内容を確認して再度お試しください。');
+    }
+
+    return response.json();
+  },
+
+  async getHeatmapData(params?: {
+    category?: string;
+    days?: number;
+    min_reports?: number;
+    userLat?: number;
+    userLon?: number;
+    radius?: number;
+    grid_m?: number;
+  }) {
+    const searchParams = new URLSearchParams();
+
+    if (params?.category) searchParams.set('category', params.category);
+    if (params?.days) searchParams.set('days', params.days.toString());
+    if (params?.min_reports) searchParams.set('min_reports', params.min_reports.toString());
+    if (params?.userLat) searchParams.set('userLat', params.userLat.toString());
+    if (params?.userLon) searchParams.set('userLon', params.userLon.toString());
+    if (params?.radius) searchParams.set('radius', params.radius.toString());
+    if (params?.grid_m) searchParams.set('grid_m', params.grid_m.toString());
+
+    const query = searchParams.toString();
+    const url = `${this.baseUrl}/api/heatmap${query ? `?${query}` : ''}`;
+
+    try {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Network error' }));
+        throw new Error(error.error || 'Failed to fetch heatmap data');
+      }
+
+      return response.json();
+    } catch (fetchError) {
+      // Specifically handle connection refused and network errors
+      console.error('API fetch failed:', fetchError);
+      throw new Error('CONNECTION_REFUSED');
+    }
+  },
+};

--- a/frontend/src/lib/supabase.test.ts
+++ b/frontend/src/lib/supabase.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { apiClient } from './apiClient';
+
+describe('apiClient.submitReport', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('replaces browser-specific network errors with an actionable Japanese message', async () => {
+    const fetchMock = jest.fn<typeof global.fetch>();
+    fetchMock.mockRejectedValue(new TypeError('Load failed'));
+    global.fetch = fetchMock;
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(apiClient.submitReport({
+      lat: 34.6937,
+      lon: 135.5023,
+      category: 'walk_smoke',
+    })).rejects.toThrow('報告サーバーに接続できません。時間をおいてからもう一度お試しください。');
+  });
+
+  it('shows a stable service error when the API cannot save the report', async () => {
+    const fetchMock = jest.fn<typeof global.fetch>();
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: jest.fn(() => Promise.resolve({
+        success: false,
+        error: 'Failed to save report',
+      })),
+    } as unknown as Response);
+    global.fetch = fetchMock;
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(apiClient.submitReport({
+      lat: 34.6937,
+      lon: 135.5023,
+      category: 'stand_smoke',
+    })).rejects.toThrow('現在、報告を保存できません。時間をおいてからもう一度お試しください。');
+  });
+});

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,70 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
+export { apiClient } from './apiClient';
+
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
-
-// API client for backend communication
-export const apiClient = {
-  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8787',
-  
-  async submitReport(data: {
-    lat: number;
-    lon: number;
-    category: 'walk_smoke' | 'stand_smoke';
-  }) {
-    const response = await fetch(`${this.baseUrl}/api/reports`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(data),
-    });
-    
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.error || 'Failed to submit report');
-    }
-    
-    return response.json();
-  },
-  
-  async getHeatmapData(params?: {
-    category?: string;
-    days?: number;
-    min_reports?: number;
-    userLat?: number;
-    userLon?: number;
-    radius?: number;
-    grid_m?: number;
-  }) {
-    const searchParams = new URLSearchParams();
-    
-    if (params?.category) searchParams.set('category', params.category);
-    if (params?.days) searchParams.set('days', params.days.toString());
-    if (params?.min_reports) searchParams.set('min_reports', params.min_reports.toString());
-    if (params?.userLat) searchParams.set('userLat', params.userLat.toString());
-    if (params?.userLon) searchParams.set('userLon', params.userLon.toString());
-    if (params?.radius) searchParams.set('radius', params.radius.toString());
-    if (params?.grid_m) searchParams.set('grid_m', params.grid_m.toString());
-    
-    const url = `${this.baseUrl}/api/heatmap${searchParams.toString() ? '?' + searchParams.toString() : ''}`;
-    
-    try {
-      const response = await fetch(url);
-      
-      if (!response.ok) {
-        const error = await response.json().catch(() => ({ error: 'Network error' }));
-        throw new Error(error.error || 'Failed to fetch heatmap data');
-      }
-      
-      return response.json();
-    } catch (fetchError) {
-      // Specifically handle connection refused and network errors
-      console.error('API fetch failed:', fetchError);
-      throw new Error('CONNECTION_REFUSED');
-    }
-  },
-  
-};


### PR DESCRIPTION
## 変更内容

- APIハンドラーの成功・失敗レスポンスへ共通CORSヘッダーを付与
- 報告INSERT時に、RLSと整合するSupabase service-roleキーを優先
- APIクライアントをSupabaseクライアントから分離
- ブラウザ固有の `Load failed` を、利用者向けの日本語エラー案内へ変換
- ネットワーク障害と保存失敗の回帰テストを追加

## 原因

Supabaseプロジェクトの停止中にWorkerの上流通信が失敗し、APIエラー応答にCORSヘッダーが付かなかったため、ブラウザがレスポンス本文を読めず `Load failed` を表示していました。加えて、報告テーブルのRLSはservice roleのみINSERT可である一方、報告ハンドラーは匿名キーを使用していました。

## 利用者への影響

- 上流障害時にも生の `Load failed` ではなく、再試行可能な日本語案内が表示されます。
- 復旧後の報告保存がRLS設定と整合します。
- ヒートマップなど他のAPIエラーもブラウザから正しく読めます。

## 検証

- `frontend`: `npm run typecheck`
- `frontend`: `npm run lint`
- `frontend`: `npm test -- --runInBand`（2件成功）
- `frontend`: `npm run build`
- `backend`: `npx -p typescript tsc --noEmit`
- ローカルWorker実通信で400/500レスポンスのCORSヘッダーを確認
- Supabase再開後、本番ヒートマップAPIが200で実データを返すことを確認